### PR TITLE
Added ability to override image builder parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ build:
 
         # Provisioning script
         script: images/install.sh
+
+        # Override image build parameters, for instance Packer parameters
+        override:
+          disk_size: "10G"
+
       manifest: manifests/genesis-core.yaml
       
       # List of artifacts in the element

--- a/genesis_devtools/builder/base.py
+++ b/genesis_devtools/builder/base.py
@@ -13,12 +13,12 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import annotations
 
 import abc
 import os
 import typing as tp
 
-from genesis_devtools.logger import AbstractLogger
 from genesis_devtools import constants as c
 
 
@@ -28,9 +28,9 @@ class Image(tp.NamedTuple):
     script: str
     profile: c.ImageProfileType = "ubuntu_24"
     format: c.ImageFormatType = "raw"
-    name: tp.Optional[str] = None
-    envs: tp.Optional[tp.List[str]] = None
-    override: tp.Optional[tp.Dict[str, tp.Any]] = None
+    name: str | None = None
+    envs: tp.List[str] | None = None
+    override: tp.Dict[str, tp.Any] | None = None
 
     @classmethod
     def from_config(

--- a/genesis_devtools/packer/ubuntu_24/ubuntu-24.pkr.hcl
+++ b/genesis_devtools/packer/ubuntu_24/ubuntu-24.pkr.hcl
@@ -14,6 +14,21 @@ locals {
   }
 }
 
+variable cpus {
+  type    = number
+  default = 4
+}
+
+variable memory {
+  type    = number
+  default = 4096
+}
+
+variable disk_size {
+  type    = string
+  default = "4500M"
+}
+
 data "sshkey" "install" {
   name = "packer"
 }
@@ -24,10 +39,10 @@ source "qemu" "ubuntu-24" {
   accelerator               = "kvm"
   boot_wait                 = "5s"
   boot_command              = ["<enter>"]
-  cpus                      = 4
-  memory                    = 4092
+  cpus                      = var.cpus
+  memory                    = var.memory
   disk_image                = true
-  disk_size                 = "4000M"
+  disk_size                 = var.disk_size
   disk_interface            = "virtio-scsi"
   disk_cache                = "unsafe"
   disk_discard              = "unmap"

--- a/genesis_devtools/tests/unit/test_packer.py
+++ b/genesis_devtools/tests/unit/test_packer.py
@@ -1,0 +1,34 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from genesis_devtools.builder import packer
+
+
+class TestPackerVariable:
+
+    def test_packer_var_int(self) -> None:
+        var = packer.PackerVariable(name="cpus", value=1)
+        assert var.render() == "cpus = 1"
+
+    def test_packer_var_str(self) -> None:
+        var = packer.PackerVariable(name="disk_size", value="10G")
+        assert var.render() == 'disk_size = "10G"'
+
+    def test_packer_content(self) -> None:
+        content = packer.PackerVariable.variable_file_content(
+            {"disk_size": "10G", "cpus": 1, "memory": 1024}
+        )
+        assert content == 'disk_size = "10G"\ncpus = 1\nmemory = 1024'


### PR DESCRIPTION
This change adds ability to override some default parameters for the image builder (Packer in our case). For instance:

```yaml
build:
...
  elements:
      # List of images in the element
    - images:
      - name: genesis-core
...
        # Override image build parameters, for instance Packer parameters
        override:
          disk_size: "10G"
```

Image size after building is 10Gb in the example above .