### PR TITLE
Fixed the package name and tiny fix for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Before you can install and use genesis tools you need to install several require
 Install packages
 ```sh
 sudo apt update
-sudo apt install qemu-kvm libvirt-daemon-system mkisofs
+sudo apt install qemu-kvm libvirt-daemon-system libvirt-dev mkisofs
 ```
 
 Add user to group

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = Genesis Dev Tools
+name = genesis-devtools
 summary = Tools to manager life cycle of Genesis projects.
 description_file =
     README.md


### PR DESCRIPTION
- The package name was fixed. It's called `genesis-devtools`
- A tiny fix for the docs, added libvirt-dev in dependencies