### PR TITLE
Build suffix option for the build command

### DIFF
--- a/genesis_devtools/builder/base.py
+++ b/genesis_devtools/builder/base.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 import abc
 import os
 import typing as tp
+import dataclasses
 
 from genesis_devtools import constants as c
 
 
-class Image(tp.NamedTuple):
+@dataclasses.dataclass
+class Image:
     """Image representation."""
 
     script: str

--- a/genesis_devtools/builder/builder.py
+++ b/genesis_devtools/builder/builder.py
@@ -13,6 +13,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import annotations
 
 import typing as tp
 import tempfile
@@ -51,14 +52,18 @@ class SimpleBuilder:
 
     def build(
         self,
-        build_dir: tp.Optional[str] = None,
-        developer_keys: tp.Optional[str] = None,
+        build_dir: str | None = None,
+        developer_keys: str | None = None,
+        build_suffix: str = "",
     ) -> None:
         """Build all elements."""
         self._logger.important("Building elements")
         for e in self._elements:
             self._logger.info(f"Building element: {e}")
             for img in e.images:
+                if build_suffix:
+                    img.name = f"{img.name}.{build_suffix}"
+
                 # The build_dir is used only for debugging purposes to observe
                 # the content of the image. In production, the image is built
                 # in a temporary directory.

--- a/genesis_devtools/cmd/cli.py
+++ b/genesis_devtools/cmd/cli.py
@@ -71,6 +71,14 @@ def main() -> None:
     help="Path to developer public key",
 )
 @click.option(
+    "-s",
+    "--version-suffix",
+    default="none",
+    type=click.Choice([s for s in tp.get_args(c.VersionSuffixType)]),
+    show_default=True,
+    help="Version suffix will be used for the build",
+)
+@click.option(
     "-f",
     "--force",
     default=False,
@@ -86,6 +94,7 @@ def build_cmd(
     build_dir: tp.Optional[str],
     output_dir: tp.Optional[str],
     developer_key_path: tp.Optional[str],
+    version_suffix: c.VersionSuffixType,
     force: bool,
     project_dir: str,
 ) -> None:
@@ -128,13 +137,18 @@ def build_cmd(
         os.path.join(project_dir, c.DEF_GEN_WORK_DIR_NAME)
     )
 
+    # Prepare a build suffix
+    build_suffix = utils.get_version_suffix(
+        version_suffix, project_dir=project_dir
+    )
+
     for _, build in builds.items():
         builder = SimpleBuilder.from_config(
             work_dir, build, packer_image_builder, logger
         )
         with tempfile.TemporaryDirectory() as temp_dir:
             builder.fetch_dependency(deps_dir or temp_dir)
-            builder.build(build_dir, developer_keys)
+            builder.build(build_dir, developer_keys, build_suffix)
 
 
 @main.command("bootstrap", help="Bootstrap genesis locally")

--- a/genesis_devtools/constants.py
+++ b/genesis_devtools/constants.py
@@ -28,6 +28,8 @@ GENESIS_META_TAG = "genesis:genesis"
 ENV_GEN_DEV_KEYS = "GEN_DEV_KEYS"
 
 # Types
-ImageProfileType = tp.Literal["ubuntu_24"]
+ImageProfileType = tp.Literal["ubuntu_24", "genesis_base"]
 ImageFormatType = tp.Literal["raw", "qcow2"]
 NetType = tp.Literal["network", "bridge"]
+
+VersionSuffixType = tp.Literal["latest", "none", "element"]

--- a/genesis_devtools/utils.py
+++ b/genesis_devtools/utils.py
@@ -164,3 +164,19 @@ def wait_for(
         time.sleep(step)
 
     print(f"\r{title} ... ok")
+
+
+def get_version_suffix(version_type: c.VersionSuffixType, **kwargs) -> str:
+    if version_type == "latest":
+        return "latest"
+    elif version_type == "none":
+        return ""
+    elif version_type == "element":
+        if "project_dir" not in kwargs:
+            raise ValueError(
+                "project_dir is required for element version type"
+            )
+        project_dir = kwargs["project_dir"]
+        return get_project_version(project_dir)
+
+    raise ValueError(f"Invalid version type {version_type}")


### PR DESCRIPTION
A small improvements for devtools adds the `--version-suffix` parameter to the `build` command. The parameter allows to apply version/build suffix to images after build. There are three options:
- `none` (default). Nothing adds.
- `latest`. The `latest` suffix is added to name - genesis-base.**latest**.qcow2
- `element`. The element version is added to name - genesis-base.**0.0.7-dev+20250313204935.4a2230e7**.qcow2