### PR TITLE
Closed #30: Create directory during dependencies copying process

### DIFF
--- a/genesis_devtools/builder/dependency.py
+++ b/genesis_devtools/builder/dependency.py
@@ -78,7 +78,7 @@ class LocalPathDependency(base.AbstractDependency):
 class HttpDependency(base.AbstractDependency):
     """HTTP dependency item."""
 
-    CHUNK_SIZE = 32768
+    CHUNK_SIZE = 65536
 
     def __init__(self, endpoint: str, img_dest: str) -> None:
         super().__init__()

--- a/genesis_devtools/builder/packer.py
+++ b/genesis_devtools/builder/packer.py
@@ -33,6 +33,7 @@ file_provisioner_tmpl = """
   }}
   provisioner "shell" {{
     inline = [
+      "sudo mkdir -p {destination_dir}",
       "sudo mv {tmp_destination} {destination}",
     ]
   }}
@@ -141,6 +142,7 @@ class PackerBuilder(base.DummyImageBuilder):
             provisioners.append(
                 file_provisioner_tmpl.format(
                     source=dep.local_path,
+                    destination_dir=os.path.dirname(dep.img_dest),
                     destination=dep.img_dest,
                     tmp_destination=tmp_dest,
                 )


### PR DESCRIPTION
Resolved issue #30. If the destination directory doesn't exist, it will be created.