### PR TITLE
Added compression option for backup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,3 +295,11 @@ genesis backup -oneshot
 ```
 
 This command will backup the current installation to the specified directory once and exit.
+
+### Compuressed Backup
+
+Run backup of all libvirt domains and store a compressed archive of the backup in the current directory:
+
+```bash
+genesis backup --compress
+```

--- a/genesis_devtools/utils.py
+++ b/genesis_devtools/utils.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import time
+import shutil
 import itertools
 import typing as tp
 from importlib.metadata import entry_points
@@ -212,3 +213,24 @@ def human_readable_size(size: int, decimal_places: int = 2):
 def backup_path(backup_dir: str) -> str:
     backup_relative_path = time.strftime("%Y-%m-%d-%H-%M-%S")
     return os.path.join(backup_dir, backup_relative_path)
+
+
+def compress_dir(
+    directory: str, output_dir: str, compression_format: str = "gztar"
+) -> None:
+    """
+    Compresses the specified directory and places the archive in the
+    output directory.
+
+    :param directory: The path to the directory to be compressed.
+    :param output_dir: The path to the directory where the compressed
+                       archive will be placed.
+    """
+    # Ensure the output directory exists
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Define the base name for the archive (without extension)
+    archive_base_name = os.path.join(output_dir, os.path.basename(directory))
+
+    # Create a zip archive of the directory
+    shutil.make_archive(archive_base_name, compression_format, directory)


### PR DESCRIPTION
This commit introduces a new feature to the backup command in the CLI tool, allowing users to compress their backups for more efficient storage management. The `--compress` flag can be used to enable this option, which compresses the backup directory into a `tar.gz` file and places it in the specified output directory.