### PR TITLE
Added new path from env variable dependency

### DIFF
--- a/genesis_devtools/builder/packer.py
+++ b/genesis_devtools/builder/packer.py
@@ -136,6 +136,13 @@ class PackerBuilder(base.DummyImageBuilder):
         # Data provisioners
         provisioners = []
         for i, dep in enumerate(deps):
+            if not dep.local_path:
+                self._logger.warn(
+                    f"Dependency {dep.img_dest} has no local path "
+                    "and will be skipped"
+                )
+                continue
+
             tmp_dest = os.path.join(
                 "/tmp/", os.path.basename(dep.img_dest) + f"_{i}"
             )

--- a/genesis_devtools/tests/unit/conftest.py
+++ b/genesis_devtools/tests/unit/conftest.py
@@ -87,3 +87,23 @@ build:
 """
     cfg = yaml.safe_load(fixture)
     return cfg["build"]
+
+
+@pytest.fixture
+def build_env_config() -> tp.Dict[str, tp.Any]:
+    fixture = """
+build:
+  deps:
+    - dst: /opt/genesis_devtools
+      optional: false
+      path:
+        env: PATH_FROM_ENV
+  elements:
+    - images:
+      - name: genesis-core
+        format: raw
+        profile: ubuntu_24
+        script: images/install.sh
+"""
+    cfg = yaml.safe_load(fixture)
+    return cfg["build"]

--- a/genesis_devtools/tests/unit/test_dependency.py
+++ b/genesis_devtools/tests/unit/test_dependency.py
@@ -113,3 +113,36 @@ class TestDependency:
             assert os.path.exists("/tmp/___deps_dir/genesis_templates")
         finally:
             shutil.rmtree("/tmp/___deps_dir")
+
+    def test_env_path_from_config(
+        self, build_env_config: tp.Dict[str, tp.Any]
+    ) -> None:
+        work_dir = "/tmp/work_dir"
+        dep = deps.LocalEnvPathDependency.from_config(
+            build_env_config["deps"][0],
+            work_dir,
+        )
+
+        assert dep.img_dest == "/opt/genesis_devtools"
+        assert dep._env_path == "PATH_FROM_ENV"
+        assert dep.local_path is None
+
+    def test_env_path_fetch(
+        self, build_env_config: tp.Dict[str, tp.Any]
+    ) -> None:
+        os.makedirs("/tmp/genesis_core_test_dir", exist_ok=True)
+        os.environ["PATH_FROM_ENV"] = "/tmp/genesis_core_test_dir"
+
+        dep = deps.LocalEnvPathDependency.from_config(
+            build_env_config["deps"][0],
+            "/tmp",
+        )
+
+        os.makedirs("/tmp/___deps_dir", exist_ok=True)
+        dep.fetch("/tmp/___deps_dir")
+
+        try:
+            assert os.path.exists("/tmp/___deps_dir/genesis_core_test_dir")
+        finally:
+            shutil.rmtree("/tmp/genesis_core_test_dir")
+            shutil.rmtree("/tmp/___deps_dir")


### PR DESCRIPTION
Similar to the `path` dependency but the actual path to file or directory is specified via an environment variable:

```yaml
  deps:
    - dst: /opt/genesis_devtools
      path:
        env: LOCAL_AGENT_PATH
```

Also an additional parameter `optional` may be specified:

```
  deps:
    - dst: /opt/genesis_devtools
      optional: true
      path:
        env: LOCAL_AGENT_PATH
```

The optional dependency will be omitted if it absent. The main motivation for this option is for local development when we would like to put some local file, directory but for production build we will take a package with specific version.