### PR TITLE
Fixed wrong usage is_flag option in click

### DIFF
--- a/genesis_devtools/cmd/cli.py
+++ b/genesis_devtools/cmd/cli.py
@@ -86,8 +86,6 @@ def main() -> None:
 @click.option(
     "-f",
     "--force",
-    default=False,
-    type=bool,
     show_default=True,
     is_flag=True,
     help="Rebuild if the output already exists",


### PR DESCRIPTION
Due to wrong usage of `is_flag` option force rebuild functionality was broken.