### PR TITLE
Added ability to set default value for envs

### DIFF
--- a/genesis_devtools/builder/base.py
+++ b/genesis_devtools/builder/base.py
@@ -31,8 +31,8 @@ class Image:
     profile: c.ImageProfileType = "ubuntu_24"
     format: c.ImageFormatType = "raw"
     name: str | None = None
-    envs: tp.List[str] | None = None
-    override: tp.Dict[str, tp.Any] | None = None
+    envs: list[str] | None = None
+    override: dict[str, tp.Any] | None = None
 
     @classmethod
     def from_config(


### PR DESCRIPTION
Now it's possible to set default value for environment variables. This value is used if the variable isn't set in the shell.

Example:
```yaml
  elements:
    - images:
      - name: genesis-base
        format: qcow2
        envs:
          - A
          - B=foo
```

The `A` variable has default behavior. If it's not set in the shell an empty value is set to it. But for the `B` variable the string "foo" is set in this case.