### PR TITLE
Added ability to capture envs by wildcard

### DIFF
--- a/genesis_devtools/builder/packer.py
+++ b/genesis_devtools/builder/packer.py
@@ -127,8 +127,13 @@ class PackerBuilder(base.DummyImageBuilder):
         result = []
 
         for env in envs:
+            # Check if the env is a wildcard
+            if env.endswith("*"):
+                for _env in (e for e in os.environ if e.startswith(env[:-1])):
+                    result.append(f'{_env}="{os.environ[_env]}"')
+                continue
             # Check if there a default value for the env
-            if "=" in env:
+            elif "=" in env:
                 name, value = tuple(e.strip() for e in env.split("="))
             else:
                 name, value = env.strip(), ""


### PR DESCRIPTION
Added another way to pass environment variables to build time. It can be done using wildcard `*`:

```yaml
  elements:
    # List of images in the element
    - images:
      - name: genesis-base
        format: qcow2
        envs:
          - GEN_USER_PASSWD
          - LOLO__*
```

All environment variables that are started from "LOLO" are captured and passed to build image scripts.