### PR TITLE
Hotfix: period and offset types

### DIFF
--- a/genesis_devtools/cmd/cli.py
+++ b/genesis_devtools/cmd/cli.py
@@ -449,8 +449,8 @@ def get_project_version_cmd(element_dir: str) -> None:
 def bakcup_cmd(
     name: tp.List[str] | None,
     backup_dir: str,
-    period: c.BackupPeriod,
-    offset: c.BackupPeriod | None,
+    period: str,
+    offset: str | None,
     oneshot: bool,
     compress: bool,
     encrypt: bool,
@@ -461,6 +461,10 @@ def bakcup_cmd(
         raise click.UsageError(
             "The encrypt flag can be used only with the compress flag."
         )
+
+    period = c.BackupPeriod(period)
+    if offset:
+        offset = c.BackupPeriod(offset)
 
     # Need to specify encryption key and initialization vector via
     # environment variables.


### PR DESCRIPTION
One of the last changes broke the `period` and `offset` types. This is a hotfix to have an ability to run `backup` command.