### PR TITLE
Skip image compaction + issue fstrim on finish

### DIFF
--- a/genesis_devtools/packer/debian_12/debian-12.pkr.hcl
+++ b/genesis_devtools/packer/debian_12/debian-12.pkr.hcl
@@ -114,6 +114,9 @@ sudo cloud-init clean --log --seed
 # Sync FS
 sudo sync
 
+# Minify orphan space
+sudo fstrim -a
+
 # shutdown machine
 sudo poweroff
 EOF

--- a/genesis_devtools/packer/genesis_base/genesis-base.pkr.hcl
+++ b/genesis_devtools/packer/genesis_base/genesis-base.pkr.hcl
@@ -102,7 +102,10 @@ sudo cloud-init clean --log --seed
 # Sync FS
 sudo sync
 
-# shutdown machine
+# Minify orphan space
+sudo fstrim -a
+
+# Shutdown machine
 sudo poweroff
 EOF
 }

--- a/genesis_devtools/packer/genesis_core/genesis-core.pkr.hcl
+++ b/genesis_devtools/packer/genesis_core/genesis-core.pkr.hcl
@@ -104,6 +104,9 @@ sudo cloud-init clean --log --seed
 # Sync FS
 sudo sync
 
+# Minify orphan space
+sudo fstrim -a
+
 # shutdown machine
 sudo poweroff
 EOF

--- a/genesis_devtools/packer/genesis_custom/genesis-custom.pkr.hcl
+++ b/genesis_devtools/packer/genesis_custom/genesis-custom.pkr.hcl
@@ -112,6 +112,9 @@ sudo cloud-init clean --log --seed
 # Sync FS
 sudo sync
 
+# Minify orphan space
+sudo fstrim -a
+
 # shutdown machine
 sudo poweroff
 EOF

--- a/genesis_devtools/packer/ubuntu_24/ubuntu-24.pkr.hcl
+++ b/genesis_devtools/packer/ubuntu_24/ubuntu-24.pkr.hcl
@@ -114,6 +114,9 @@ sudo cloud-init clean --log --seed
 # Sync FS
 sudo sync
 
+# Minify orphan space
+sudo fstrim -a
+
 # shutdown machine
 sudo poweroff
 EOF


### PR DESCRIPTION
Image compaction is essentially an additional image convert, but we already use raw.gz as primary image type,
so remove excess converts and issue fstrim explicitly for additional gains.

genesis_db, before (compression time excluded):
```
Build 'qemu.genesis-db-pg' finished after 1 minute 56 seconds.

-rw-r--r--  1 gmelikov docker   1212786475 Sep 29 14:25 genesis-db-pg.raw.gz
```

After:
```
Build 'qemu.genesis-db-pg' finished after 1 minute 42 seconds.

-rw-r--r--  1 gmelikov docker   1207252879 Sep 29 14:22 genesis-db-pg.raw.gz
```